### PR TITLE
Add purchase order approval workflow

### DIFF
--- a/src/components/purchase-orders/POApproval.jsx
+++ b/src/components/purchase-orders/POApproval.jsx
@@ -1,0 +1,164 @@
+import React, { useState } from 'react'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Box,
+  Typography,
+  Alert
+} from '@mui/material'
+import { CheckCircle, Cancel } from '@mui/icons-material'
+
+function POApproval({ order, open, onClose, onApprove, onReject, loading }) {
+  const [comments, setComments] = useState('')
+  const [action, setAction] = useState(null) // 'approve' or 'reject'
+  const [error, setError] = useState('')
+
+  const handleApprove = () => {
+    setAction('approve')
+    setError('')
+  }
+
+  const handleReject = () => {
+    if (!comments.trim()) {
+      setError('Rejection comments are required')
+      return
+    }
+    setAction('reject')
+    setError('')
+  }
+
+  const handleConfirm = async () => {
+    try {
+      if (action === 'approve') {
+        await onApprove(order.id, comments)
+      } else if (action === 'reject') {
+        await onReject(order.id, comments)
+      }
+      handleClose()
+    } catch (err) {
+      setError(err.response?.data?.message || 'Action failed')
+    }
+  }
+
+  const handleClose = () => {
+    setComments('')
+    setAction(null)
+    setError('')
+    onClose()
+  }
+
+  if (!order) return null
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        {action ? 'Confirm Action' : 'Approve or Reject Purchase Order'}
+      </DialogTitle>
+
+      <DialogContent>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        <Box sx={{ mb: 3 }}>
+          <Typography variant="body2" color="text.secondary">
+            PO Number
+          </Typography>
+          <Typography variant="h6">{order.poNumber}</Typography>
+        </Box>
+
+        <Box sx={{ mb: 3 }}>
+          <Typography variant="body2" color="text.secondary">
+            Supplier
+          </Typography>
+          <Typography variant="body1">{order.supplierName}</Typography>
+        </Box>
+
+        <Box sx={{ mb: 3 }}>
+          <Typography variant="body2" color="text.secondary">
+            Total Amount
+          </Typography>
+          <Typography variant="h6" color="primary">
+            ${order.totalAmount.toLocaleString()}
+          </Typography>
+        </Box>
+
+        {!action && (
+          <TextField
+            fullWidth
+            multiline
+            rows={4}
+            label="Comments (Optional for Approval, Required for Rejection)"
+            value={comments}
+            onChange={(e) => setComments(e.target.value)}
+            placeholder="Add your comments here..."
+          />
+        )}
+
+        {action && (
+          <Alert severity={action === 'approve' ? 'success' : 'warning'}>
+            <Typography variant="body2">
+              Are you sure you want to <strong>{action}</strong> this purchase order?
+              {action === 'reject' && comments && (
+                <>
+                  <br />
+                  <strong>Reason:</strong> {comments}
+                </>
+              )}
+            </Typography>
+          </Alert>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        {!action ? (
+          <>
+            <Button onClick={handleClose} disabled={loading}>
+              Cancel
+            </Button>
+            <Button
+              variant="outlined"
+              color="error"
+              startIcon={<Cancel />}
+              onClick={handleReject}
+              disabled={loading}
+            >
+              Reject
+            </Button>
+            <Button
+              variant="contained"
+              color="success"
+              startIcon={<CheckCircle />}
+              onClick={handleApprove}
+              disabled={loading}
+            >
+              Approve
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button onClick={() => setAction(null)} disabled={loading}>
+              Back
+            </Button>
+            <Button
+              variant="contained"
+              color={action === 'approve' ? 'success' : 'error'}
+              onClick={handleConfirm}
+              disabled={loading}
+            >
+              {loading ? 'Processing...' : `Confirm ${action === 'approve' ? 'Approval' : 'Rejection'}`}
+            </Button>
+          </>
+        )}
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default POApproval

--- a/src/components/purchase-orders/PODetails.jsx
+++ b/src/components/purchase-orders/PODetails.jsx
@@ -18,9 +18,12 @@ import {
   Divider,
   Box
 } from '@mui/material'
-import { Close } from '@mui/icons-material'
+import { Close, CheckCircle, Cancel } from '@mui/icons-material'
+import { useAuth } from '../../context/AuthContext'
 
-function PODetails({ order, open, onClose }) {
+function PODetails({ order, open, onClose, onApprove, onReject }) {
+  const { user } = useAuth()
+  
   if (!order) return null
 
   const formatCurrency = (amount) => {
@@ -95,6 +98,47 @@ function PODetails({ order, open, onClose }) {
               </>
             )}
           </Grid>
+          
+          {/* Approval Information */}
+          {(order.approvedByName || order.rejectionComments) && (
+            <>
+              <Grid item xs={12}>
+                <Divider sx={{ my: 2 }} />
+                <Typography variant="h6" gutterBottom>
+                  Approval Information
+                </Typography>
+              </Grid>
+              
+              {order.approvedByName && (
+                <Grid item xs={12} md={6}>
+                  <Typography variant="subtitle2" color="text.secondary">
+                    {order.status === 'CANCELLED' ? 'Rejected By' : 'Approved By'}
+                  </Typography>
+                  <Typography variant="body1" gutterBottom>
+                    {order.approvedByName}
+                  </Typography>
+                  
+                  <Typography variant="subtitle2" color="text.secondary">
+                    {order.status === 'CANCELLED' ? 'Rejection Date' : 'Approval Date'}
+                  </Typography>
+                  <Typography variant="body1" gutterBottom>
+                    {formatDate(order.approvedDate)}
+                  </Typography>
+                </Grid>
+              )}
+              
+              {order.rejectionComments && (
+                <Grid item xs={12}>
+                  <Typography variant="subtitle2" color="text.secondary">
+                    Rejection Comments
+                  </Typography>
+                  <Paper sx={{ p: 2, bgcolor: 'error.light', color: 'error.contrastText' }}>
+                    <Typography variant="body2">{order.rejectionComments}</Typography>
+                  </Paper>
+                </Grid>
+              )}
+            </>
+          )}
         </Grid>
 
         <Divider sx={{ my: 3 }} />
@@ -175,6 +219,34 @@ function PODetails({ order, open, onClose }) {
       </DialogContent>
       
       <DialogActions>
+        {/* Show approval buttons only for DRAFT status and HOSPITAL_MANAGER role */}
+        {order.status === 'DRAFT' && user?.role === 'HOSPITAL_MANAGER' && (
+          <>
+            <Button
+              variant="outlined"
+              color="error"
+              startIcon={<Cancel />}
+              onClick={() => {
+                // This will be handled by parent component
+                if (onReject) onReject(order)
+              }}
+            >
+              Reject
+            </Button>
+            <Button
+              variant="contained"
+              color="success"
+              startIcon={<CheckCircle />}
+              onClick={() => {
+                // This will be handled by parent component
+                if (onApprove) onApprove(order)
+              }}
+            >
+              Approve
+            </Button>
+            <Box sx={{ flexGrow: 1 }} />
+          </>
+        )}
         <Button onClick={onClose} startIcon={<Close />}>
           Close
         </Button>

--- a/src/components/purchase-orders/POList.jsx
+++ b/src/components/purchase-orders/POList.jsx
@@ -179,11 +179,23 @@ function POList({ onView, onEdit, canEdit, canDelete, refreshTrigger }) {
                       : '-'}
                   </TableCell>
                   <TableCell align="center">
-                    <Chip 
-                      label={order.status} 
-                      color={getStatusColor(order.status)}
-                      size="small"
-                    />
+                    <Box display="flex" alignItems="center" justifyContent="center" gap={1}>
+                      <Chip 
+                        label={order.status} 
+                        color={getStatusColor(order.status)}
+                        size="small"
+                      />
+                      {order.status === 'DRAFT' && (
+                        <Tooltip title="Pending Approval">
+                          <Chip 
+                            label="!" 
+                            size="small" 
+                            color="warning"
+                            sx={{ width: 24, minWidth: 24 }}
+                          />
+                        </Tooltip>
+                      )}
+                    </Box>
                   </TableCell>
                   <TableCell align="right">
                     {formatCurrency(order.totalAmount)}

--- a/src/components/purchase-orders/PendingApprovalsList.jsx
+++ b/src/components/purchase-orders/PendingApprovalsList.jsx
@@ -1,0 +1,155 @@
+import React, { useState, useEffect } from 'react'
+import {
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TablePagination,
+  Chip,
+  IconButton,
+  Tooltip,
+  Typography,
+  CircularProgress,
+  Button
+} from '@mui/material'
+import { Visibility, CheckCircle, Cancel } from '@mui/icons-material'
+import { getPendingApprovals } from '../../services/api'
+
+function PendingApprovalsList({ onView, onApprove, refreshTrigger }) {
+  const [orders, setOrders] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [pagination, setPagination] = useState({
+    page: 0,
+    size: 10,
+    totalElements: 0
+  })
+
+  useEffect(() => {
+    fetchPendingApprovals()
+  }, [pagination.page, pagination.size, refreshTrigger])
+
+  const fetchPendingApprovals = async () => {
+    try {
+      setLoading(true)
+      const response = await getPendingApprovals({
+        page: pagination.page,
+        size: pagination.size
+      })
+      setOrders(response.data.content)
+      setPagination(prev => ({
+        ...prev,
+        totalElements: response.data.totalElements
+      }))
+    } catch (error) {
+      console.error('Error fetching pending approvals:', error)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const formatCurrency = (amount) => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD'
+    }).format(amount)
+  }
+
+  const formatDate = (dateString) => {
+    return new Date(dateString).toLocaleDateString()
+  }
+
+  if (loading && orders.length === 0) {
+    return (
+      <Box display="flex" justifyContent="center" p={3}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  if (orders.length === 0) {
+    return (
+      <Paper sx={{ p: 3, textAlign: 'center' }}>
+        <Typography color="text.secondary">
+          No pending approvals at the moment
+        </Typography>
+      </Paper>
+    )
+  }
+
+  return (
+    <Box>
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell><strong>PO Number</strong></TableCell>
+              <TableCell><strong>Supplier</strong></TableCell>
+              <TableCell><strong>Created By</strong></TableCell>
+              <TableCell><strong>Order Date</strong></TableCell>
+              <TableCell align="right"><strong>Total Amount</strong></TableCell>
+              <TableCell align="center"><strong>Items</strong></TableCell>
+              <TableCell align="center"><strong>Actions</strong></TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {orders.map((order) => (
+              <TableRow key={order.id} hover>
+                <TableCell>
+                  <Typography variant="body2" fontWeight="bold">
+                    {order.poNumber}
+                  </Typography>
+                </TableCell>
+                <TableCell>{order.supplierName}</TableCell>
+                <TableCell>{order.createdByName}</TableCell>
+                <TableCell>{formatDate(order.orderDate)}</TableCell>
+                <TableCell align="right">
+                  <Typography variant="body2" fontWeight="bold" color="primary">
+                    {formatCurrency(order.totalAmount)}
+                  </Typography>
+                </TableCell>
+                <TableCell align="center">
+                  <Chip label={order.totalItems} size="small" />
+                </TableCell>
+                <TableCell align="center">
+                  <Tooltip title="View Details">
+                    <IconButton size="small" onClick={() => onView(order)}>
+                      <Visibility fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Approve/Reject">
+                    <IconButton 
+                      size="small" 
+                      color="success"
+                      onClick={() => onApprove(order)}
+                    >
+                      <CheckCircle fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <TablePagination
+        component="div"
+        count={pagination.totalElements}
+        page={pagination.page}
+        onPageChange={(e, newPage) => setPagination(prev => ({ ...prev, page: newPage }))}
+        rowsPerPage={pagination.size}
+        onRowsPerPageChange={(e) => setPagination(prev => ({ 
+          ...prev, 
+          size: parseInt(e.target.value, 10),
+          page: 0 
+        }))}
+      />
+    </Box>
+  )
+}
+
+export default PendingApprovalsList

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -585,5 +585,29 @@ export const updatePurchaseOrderStatus = (id, status) => {
 export const getPurchaseOrderSummary = () => {
   return api.get('/purchase-orders/summary')
 }
+// Approve purchase order
+export const approvePurchaseOrder = (id, comments = null) => {
+  return api.post(`/purchase-orders/${id}/approve`, {
+    comments: comments
+  })
+}
+// Reject purchase order
+export const rejectPurchaseOrder = (id, comments) => {
+  return api.post(`/purchase-orders/${id}/reject`, {
+    comments: comments
+  })
+}
+// Get pending approvals (for managers)
+export const getPendingApprovals = (params = {}) => {
+  const queryParams = new URLSearchParams({
+    page: params.page || 0,
+    size: params.size || 10
+  }).toString()
+  return api.get(`/purchase-orders/pending-approvals?${queryParams}`)
+}
+// Request approval
+export const requestPurchaseOrderApproval = (id) => {
+  return api.post(`/purchase-orders/${id}/request-approval`)
+}
 
 export default api


### PR DESCRIPTION
Introduces POApproval and PendingApprovalsList components to support purchase order approval and rejection by hospital managers. Updates PODetails, POList, and PurchaseOrders page to integrate approval actions and pending approvals section. Extends API service with endpoints for approving, rejecting, and listing pending purchase orders.